### PR TITLE
Comment os capabilities properties from compute nodes of mesos cluster

### DIFF
--- a/mesos_cluster.yaml
+++ b/mesos_cluster.yaml
@@ -46,9 +46,9 @@ topology_template:
             mem_size: 2 GB
         os:
           properties:
-            type: linux
-            distribution: ubuntu
-            version: 14.04
+#            type: linux
+#            distribution: ubuntu
+#            version: 14.04
             image: linux-ubuntu-14.04-vmi
 
 
@@ -64,9 +64,9 @@ topology_template:
             mem_size: 1 GB
         os:
           properties:
-            type: linux
-            distribution: ubuntu
-            version: 14.04
+#            type: linux
+#            distribution: ubuntu
+#            version: 14.04
             image: linux-ubuntu-14.04-vmi
             
     mesos_lb_server:
@@ -84,9 +84,9 @@ topology_template:
             mem_size: 1 GB
         os:
           properties:
-            type: linux
-            distribution: ubuntu
-            version: 14.04
+#            type: linux
+#            distribution: ubuntu
+#            version: 14.04
             image: linux-ubuntu-14.04-vmi
             
   outputs:


### PR DESCRIPTION
In order to deploy mesos clusters explicitly with VMs, the compute nodes need to have only the image property of the os capability set, otherwise the orchestrator will fallback on the vanilla image identified by the properties type, distribution, version, architecture