### PR TITLE
Fix docker-kepler template

### DIFF
--- a/docker-kepler.yaml
+++ b/docker-kepler.yaml
@@ -13,9 +13,10 @@ topology_template:
 
     simple_node:
       type: tosca.nodes.indigo.Compute
-      properties:
-        public_ip: yes
       capabilities:
+        endpoint:
+          properties:
+            network_name: PUBLIC
         scalable:
           properties:
             count: 1
@@ -39,4 +40,4 @@ topology_template:
     node_ip:
       value: { get_attribute: [ simple_node, public_address, 0 ] }
     node_creds:
-      value: { get_attribute: [ simple_node, credential, 0 ] }
+      value: { get_attribute: [ simple_node, endpoint, credential, 0 ] }


### PR DESCRIPTION
Change public network definition
Change credentials retrieval for the outputs of the template