### PR TITLE
Remove _ from Compute nodes

### DIFF
--- a/disvis.yaml
+++ b/disvis.yaml
@@ -21,9 +21,9 @@ topology_template:
     disvis:
       type: tosca.nodes.indigo.Disvis
       requirements:
-        - host: disvis_server
+        - host: disvis-server
  
-    disvis_server:
+    disvis-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -46,6 +46,6 @@ topology_template:
 
   outputs:
     instance_ip:
-      value: { get_attribute: [ disvis_server, public_address, 0 ] }
+      value: { get_attribute: [ disvis-server, public_address, 0 ] }
     instance_creds:
-      value: { get_attribute: [ disvis_server, endpoint, credential, 0 ] }
+      value: { get_attribute: [ disvis-server, endpoint, credential, 0 ] }

--- a/galaxy.yaml
+++ b/galaxy.yaml
@@ -28,9 +28,9 @@ topology_template:
     local_lrms:
       type: tosca.nodes.indigo.LRMS.FrontEnd.Local
       requirements:
-        - host: galaxy_server
+        - host: galaxy-server
 
-    galaxy_server:
+    galaxy-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -56,4 +56,4 @@ topology_template:
 
   outputs:
     galaxy_url:
-      value: { concat: [ 'http://', get_attribute: [ galaxy_server, public_address, 0 ], '/galaxy' ] }
+      value: { concat: [ 'http://', get_attribute: [ galaxy-server, public_address, 0 ], '/galaxy' ] }

--- a/galaxy_elastic_cluster.yaml
+++ b/galaxy_elastic_cluster.yaml
@@ -59,11 +59,11 @@ topology_template:
     lrms_front_end:
       type: tosca.nodes.indigo.LRMS.FrontEnd.Slurm
       properties:
-        wn_ips: { get_attribute: [ lrms_wn, private_address ] }
+        wn_ips: { get_attribute: [ lrms-wn, private_address ] }
       requirements:
-        - host: lrms_server
+        - host: lrms-server
 
-    lrms_server:
+    lrms-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -85,21 +85,21 @@ topology_template:
     wn_node:
       type: tosca.nodes.indigo.LRMS.WorkerNode.Slurm
       properties:
-        front_end_ip: { get_attribute: [ lrms_server, private_address, 0 ] }
+        front_end_ip: { get_attribute: [ lrms-server, private_address, 0 ] }
       capabilities:
         wn:
           properties:
             max_instances: { get_input: wn_num }
             min_instances: 0
       requirements:
-        - host: lrms_wn
+        - host: lrms-wn
 
     galaxy_wn:
       type: tosca.nodes.indigo.GalaxyWN
       requirements:
-        - host: lrms_wn
+        - host: lrms-wn
 
-    lrms_wn:
+    lrms-wn:
       type: tosca.nodes.indigo.Compute
       capabilities:
         scalable:
@@ -115,8 +115,8 @@ topology_template:
 
   outputs:
     galaxy_url:
-      value: { concat: [ 'http://', get_attribute: [ lrms_server, public_address, 0 ], '/galaxy' ] }
+      value: { concat: [ 'http://', get_attribute: [ lrms-server, public_address, 0 ], '/galaxy' ] }
     cluster_ip:
-      value: { get_attribute: [ lrms_server, public_address, 0 ] }
+      value: { get_attribute: [ lrms-server, public_address, 0 ] }
     cluster_creds:
-      value: { get_attribute: [ lrms_server, endpoint, credential, 0 ] }
+      value: { get_attribute: [ lrms-server, endpoint, credential, 0 ] }

--- a/kepler.yaml
+++ b/kepler.yaml
@@ -21,9 +21,9 @@ topology_template:
     kepler:
       type: tosca.nodes.indigo.Kepler
       requirements:
-        - host: kepler_server
+        - host: kepler-server
 
-    kepler_server:
+    kepler-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -49,6 +49,6 @@ topology_template:
 
   outputs:
     instance_ip:
-      value: { get_attribute: [ kepler_server, public_address, 0 ] }
+      value: { get_attribute: [ kepler-server, public_address, 0 ] }
     instance_creds:
-      value: { get_attribute: [ kepler_server, endpoint, credential, 0 ] }
+      value: { get_attribute: [ kepler-server, endpoint, credential, 0 ] }

--- a/mesos_cluster.yaml
+++ b/mesos_cluster.yaml
@@ -15,23 +15,23 @@ topology_template:
         marathon_password: test_pass
         chronos_password: test_pass
       requirements:
-        - host: mesos_master_server
+        - host: mesos-master-server
 
     mesos_slave:
       type: tosca.nodes.indigo.MesosSlave
       properties:
-        master_ips: { get_attribute: [ mesos_master_server, public_address ] }
+        master_ips: { get_attribute: [ mesos-master-server, public_address ] }
       requirements:
-        - host: mesos_slave_server
+        - host: mesos-slave-server
         
     mesos_load_balancer:
       type: tosca.nodes.indigo.MesosLoadBalancer
       properties:
-        master_ips: { get_attribute: [ mesos_master_server, public_address ] }
+        master_ips: { get_attribute: [ mesos-master-server, public_address ] }
       requirements:
-        - host: mesos_lb_server        
+        - host: mesos-lb-server
 
-    mesos_master_server:
+    mesos-master-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -52,7 +52,7 @@ topology_template:
             image: linux-ubuntu-14.04-vmi
 
 
-    mesos_slave_server:
+    mesos-slave-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         scalable:
@@ -69,7 +69,7 @@ topology_template:
 #            version: 14.04
             image: linux-ubuntu-14.04-vmi
             
-    mesos_lb_server:
+    mesos-lb-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -91,7 +91,7 @@ topology_template:
             
   outputs:
     mesos_lb_ips:
-      value: { get_attribute: [ mesos_lb_server, public_address ] }
+      value: { get_attribute: [ mesos-lb-server, public_address ] }
     mesos_master_ips:
-      value: { get_attribute: [ mesos_master_server, public_address ] }
+      value: { get_attribute: [ mesos-master-server, public_address ] }
       

--- a/mesos_cluster_cms.yaml
+++ b/mesos_cluster_cms.yaml
@@ -19,29 +19,29 @@ topology_template:
       properties:
         marathon_password: test_pass
         chronos_password: test_pass
-        mysquid_host: { get_attribute: [ mesos_lb_server, public_address, 0 ] }
-        proxycache_host: { get_attribute: [ mesos_lb_server, public_address, 0 ] }
+        mysquid_host: { get_attribute: [ mesos-lb-server, public_address, 0 ] }
+        proxycache_host: { get_attribute: [ mesos-lb-server, public_address, 0 ] }
         iam_access_token: { get_input: iam_token }
       requirements:
-        - host: mesos_master_server
+        - host: mesos-master-server
 
     mesos_slave:
       type: tosca.nodes.indigo.MesosSlaveCms
       properties:
-        master_ips: { get_attribute: [ mesos_master_server, public_address ] }
-        mysquid_host: { get_attribute: [ mesos_lb_server, public_address, 0 ] }
-        proxycache_host: { get_attribute: [ mesos_lb_server, public_address, 0 ] }
+        master_ips: { get_attribute: [ mesos-master-server, public_address ] }
+        mysquid_host: { get_attribute: [ mesos-lb-server, public_address, 0 ] }
+        proxycache_host: { get_attribute: [ mesos-lb-server, public_address, 0 ] }
       requirements:
-        - host: mesos_slave_server
+        - host: mesos-slave-server
         
     mesos_load_balancer:
       type: tosca.nodes.indigo.MesosLoadBalancer
       properties:
-        master_ips: { get_attribute: [ mesos_master_server, public_address ] }
+        master_ips: { get_attribute: [ mesos-master-server, public_address ] }
       requirements:
-        - host: mesos_lb_server        
+        - host: mesos-lb-server
 
-    mesos_master_server:
+    mesos-master-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -69,7 +69,7 @@ topology_template:
             image: linux-ubuntu-14.04-vmi
 
 
-    mesos_slave_server:
+    mesos-slave-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         scalable:
@@ -86,7 +86,7 @@ topology_template:
 #            version: 14.04
             image: linux-ubuntu-14.04-vmi
             
-    mesos_lb_server:
+    mesos-lb-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -108,7 +108,7 @@ topology_template:
             
   outputs:
     mesos_lb_ips:
-      value: { get_attribute: [ mesos_lb_server, public_address ] }
+      value: { get_attribute: [ mesos-lb-server, public_address ] }
     mesos_master_ips:
-      value: { get_attribute: [ mesos_master_server, public_address ] }
+      value: { get_attribute: [ mesos-master-server, public_address ] }
       

--- a/powerfit.yaml
+++ b/powerfit.yaml
@@ -21,9 +21,9 @@ topology_template:
     powerfit:
       type: tosca.nodes.indigo.Powerfit
       requirements:
-        - host: powerfit_server
+        - host: powerfit-server
  
-    powerfit_server:
+    powerfit-server:
       type: tosca.nodes.indigo.Compute
       capabilities:
         endpoint:
@@ -46,6 +46,6 @@ topology_template:
 
   outputs:
     instance_ip:
-      value: { get_attribute: [ powerfit_server, public_address, 0 ] }
+      value: { get_attribute: [ powerfit-server, public_address, 0 ] }
     instance_creds:
-      value: { get_attribute: [ powerfit_server, endpoint, credential, 0 ] }
+      value: { get_attribute: [ powerfit-server, endpoint, credential, 0 ] }


### PR DESCRIPTION
_ is not supported in DNS names, and in some infras the DNS name is derived from the Compute name.
This patch replaces them with a dash.